### PR TITLE
feat: レスポンシブ静的コーディング

### DIFF
--- a/src/app/_components/group2/index.module.scss
+++ b/src/app/_components/group2/index.module.scss
@@ -16,26 +16,29 @@
 }
 
 .group2-wrapper {
-  margin-top: sp-vw(38);
+  display: flex;
+  flex-direction: column;
+  gap: sp-vw(20);
+  margin-top: sp-vw(40);
 
   @include media-pc {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-auto-rows: 1fr;
     gap: pc-vw(40);
-    margin-top: pc-vw(53);
+    margin-top: pc-vw(40);
   }
 }
 
 .group2-box-container {
+  height: sp-vw(170);
   padding: sp-vw(30) sp-vw(10);
-  margin-top: sp-vw(21);
   background-color: #{$color-light-light-pink};
   border-radius: sp-vw(10);
 
   @include media-pc {
-    flex: 1 1 calc(50% - #{pc-vw(20)});
-    padding: pc-vw(40) pc-vw(47);
-    margin-top: 0;
+    height: pc-vw(200);
+    padding: pc-vw(40);
     border-radius: pc-vw(10);
   }
 }
@@ -70,7 +73,7 @@
   line-height: 1.7;
 
   @include media-pc {
-    margin-top: pc-vw(36);
+    margin-top: pc-vw(30);
     font-size: pc-vw(14);
   }
 }

--- a/src/app/_components/group3/index.module.scss
+++ b/src/app/_components/group3/index.module.scss
@@ -129,7 +129,7 @@
 
   .group3-box-description {
     @include media-pc {
-      margin-top: pc-vw(37);
+      margin-top: pc-vw(42);
     }
   }
 }


### PR DESCRIPTION
## タスクのリンク

https://gizumo.backlog.com/view/GIZFE-2648

## やったこと

全てのセクションコンポーネントに対して、PC版のレイアウトに対応したレスポンシブ化を行いました。
そのために Sass の @mixin を作成し、各コンポーネントのスタイル内で @include media-pc を使用して PC サイズ専用のスタイルを適用しています。

これにより、全セクションが共通のルールで PC レイアウトに対応し、デザインの統一性と保守性が向上しています。

## やらないこと

なし

## 動作確認

- [ x ] `npm run lint:css` を実行して、CSSのLintエラーがないこと
- [ x ] `npm run lint:js` を実行して、JavaScriptのLintエラーがないこと

## 特にレビューをお願いしたい箇所

なし

## その他

なし
